### PR TITLE
Update the Game document schema and create cloud function for updating User document with decks

### DIFF
--- a/firebase/functions/package-lock.json
+++ b/firebase/functions/package-lock.json
@@ -4295,12 +4295,6 @@
         "tweetnacl": "~0.14.0"
       }
     },
-    "stackback": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha1-Gsig2Ug4SNFpXkGLbQMaPDzmjjs=",
-      "dev": true
-    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -4685,9 +4679,9 @@
       "optional": true
     },
     "typescript": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.4.tgz",
-      "integrity": "sha1-Cx22jmvfsLdn+iq2QhNqNbBZsZk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.1.tgz",
+      "integrity": "sha512-cTmIDFW7O0IHbn1DPYjkiebHxwtCMU+eTy30ZtJNBPF9j2O1ITu5XH2YnBeVRKWHqF+3JQwWJv0Q0aUgX8W7IA==",
       "dev": true
     },
     "union-value": {
@@ -4882,15 +4876,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
       "dev": true
-    },
-    "why-is-node-running": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.0.3.tgz",
-      "integrity": "sha512-XmzbFN2T859avcs5qAsiiK1iu0nUpSUXRgiGsoHPcNijxhIlp1bPQWQk6ANUljDWqBtAbIR2jF1HxR0y2l2kCA==",
-      "dev": true,
-      "requires": {
-        "stackback": "0.0.2"
-      }
     },
     "window-size": {
       "version": "0.1.4",

--- a/firebase/functions/package.json
+++ b/firebase/functions/package.json
@@ -8,12 +8,13 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "fb-clean": "firebase firestore:delete -y -r /Users/JLI7eua7cnRYBYGdWbepVqZwQEg1/Decks && firebase firestore:delete -y -r /Users/cKDlZPoerrVy3NbgR1a7HJmeW3E2/Decks",
+    "fb-clean": "sh/test-cleanup.sh",
     "test": "mocha --require ts-node/register --reporter spec test/**/*.ts"
   },
   "main": "lib/index.js",
   "dependencies": {
     "firebase-functions": "2.2.0",
+    "firebase-admin": "7.0.0",
     "@google-cloud/firestore": "0.19.0",
     "uuid": "3.3.2",
     "express": "4.16.4",
@@ -30,7 +31,7 @@
     "supertest": "3.4.2",
     "ts-node": "8.0.2",
     "tslint": "~5.8.0",
-    "typescript": "~2.8.3"
+    "typescript": "3.3.1"
   },
   "private": true
 }

--- a/firebase/functions/sh/test-cleanup.sh
+++ b/firebase/functions/sh/test-cleanup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+firebase firestore:delete -y -r /Users/JLI7eua7cnRYBYGdWbepVqZwQEg1/Decks && \
+    firebase firestore:delete -y -r /Users/cKDlZPoerrVy3NbgR1a7HJmeW3E2/Decks && \
+    firebase firestore:delete -y -r /Games

--- a/firebase/functions/src/decklist.ts
+++ b/firebase/functions/src/decklist.ts
@@ -56,7 +56,9 @@ export interface Deck {
     // The name of the deck
     name: string,
     // The cards in the deck, where the key is the Scryfall ID
-    cards: any,
+    cards: {
+        [key: string]: IdentifiedCard,
+    },
     // Optional information about the imported deck
     import_info?: {
         // The URI from which the deck was imported

--- a/firebase/functions/src/game.ts
+++ b/firebase/functions/src/game.ts
@@ -321,7 +321,7 @@ const startGameHelper = async function(gameId: string): Promise<void> {
                 .map((doc) => doc.id)
                 .sort(() => uuidv4());
             
-            await gameDocRef.set({ turn_order: { ...playerOrder } }, { merge: true })
+            await gameDocRef.set({ turn_order: playerOrder }, { merge: true });
             return;
         } else {
             throw new Response.FunctionError(

--- a/firebase/functions/src/index.ts
+++ b/firebase/functions/src/index.ts
@@ -15,3 +15,4 @@ export const startGameFunction = Game.startGameFunction;
 // User Functions
 export const createUserDocumentFunction = User.createUserDocument;
 export const deleteUserDocumentFunction = User.deleteUserDocument;
+export const updateUserDocumentWithDeckFunction = User.updateUserDocumentWithDeck;

--- a/firebase/functions/test/index.test.ts
+++ b/firebase/functions/test/index.test.ts
@@ -53,6 +53,7 @@ describe('Cloud Functions Test Suite', function() {
       });
 
       it(`The "Users/${createdUserUID}" document should exist and have uid and username populated`, async function() {
+        this.timeout(15000);
         const userDoc: Firestore.DocumentReference = await firestore.doc(`Users/${createdUserUID}`);
         const userDocExists: boolean = await TestUtils.attempt(async () => {
           const snapshot = await userDoc.get();
@@ -77,6 +78,7 @@ describe('Cloud Functions Test Suite', function() {
       });
 
       it(`The "Users/${createdUserUID}" document should not exist`, async function() {
+        this.timeout(15000);
         const userDoc: Firestore.DocumentReference = await firestore.doc(`Users/${createdUserUID}`);
         const userDocExists: boolean = await TestUtils.attempt(async () => {
           const snapshot = await userDoc.get();
@@ -415,8 +417,8 @@ describe('Cloud Functions Test Suite', function() {
       it('Validate the document in Firestore', function() {
         const data = gameDoc.data();
 
-        expect([data.turn_order['0'], data.turn_order['1']]).to.contain(functionsConfig.user1.uid);
-        expect([data.turn_order['0'], data.turn_order['1']]).to.contain(functionsConfig.user2.uid);
+        expect(data.turn_order).to.contain(functionsConfig.user1.uid);
+        expect(data.turn_order).to.contain(functionsConfig.user2.uid);
       });
     });
   });

--- a/firebase/functions/test/index.test.ts
+++ b/firebase/functions/test/index.test.ts
@@ -222,6 +222,24 @@ describe('Cloud Functions Test Suite', function() {
       });
     });
   });
+
+  describe('Tests for updateUserDocumentWithDeck', function() {
+    it(`User ${functionsConfig.user1.uid} should list the DRAGONS deck`, async function() {
+      this.timeout(5000);
+      const userDocRef = firestore.doc(`Users/${functionsConfig.user1.uid}`);
+      const userDoc = await TestUtils.attempt(async () => {
+        const tempDoc = await userDocRef.get();
+        if (!tempDoc.data().decks[user1DeckId]) {
+          throw new Error(`Expected decks[${user1DeckId}] to exist`);
+        }
+        return tempDoc;
+      })
+      const deckInfo = userDoc.data().decks[user1DeckId];
+      expect(deckInfo).to.not.be.undefined;
+      expect(deckInfo.id).to.equal(user1DeckId);
+      expect(deckInfo.name).to.equal('DRAGONS');
+    });
+  });
   
   describe('Tests for populateDeckFunction', function() {
     describe('Test populating for a deck', function() {

--- a/firebase/functions/test/test-utils.ts
+++ b/firebase/functions/test/test-utils.ts
@@ -3,7 +3,7 @@ function sleep(ms: number) {
 }
 
 /**
- * Attempts some operation up to 5 times, waiting 1 second between attempts.
+ * Attempts some operation up to 10 times, waiting 1 second between attempts.
  * 
  * @param operation The operation to attempt, which should return a Promise.
  * If the Promise resolves, then that value is returned. If it rejects, then
@@ -13,7 +13,7 @@ function sleep(ms: number) {
 export const attempt = async function(operation: () => Promise<any>): Promise<any> {
     let attempts: number = 0;
     let error: Error;
-    while (attempts < 5) {
+    while (attempts < 10) {
         try {
             attempts++;
             return await operation();


### PR DESCRIPTION
`turn_order` is now a simple array, instead of a map with the turn index as the key.

It seems something changed recently, which required explicitly pulling in firebase-admin 7.0.0 and updating typescript to 3.3.1.

Updated the `fb-clean` npm script to delegate to `sh/test-cleanup.sh`, which will delete all the Games in addition to the Decks for the two test players.

Added a Cloud Function that will update the user document with a summary of the player's decks as they are imported.

Resolves #51.
Resolves #55.