### PR TITLE
Add support for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,37 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,15 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+general:
+  branches:
+    only:
+      - circleci
 jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:7.10
+      - image: circleci/node:8.15.0
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -18,20 +22,37 @@ jobs:
 
     steps:
       - checkout
+      - ls -la
+    #   # Download and cache dependencies
+    #   - restore_cache:
+    #       keys:
+    #         - v1-dependencies-{{ checksum "package.json" }}
+    #         # fallback to using the latest cache if no exact match is found
+    #         - v1-dependencies-
 
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+    #   - run: yarn install
 
-      - run: yarn install
+    #   - save_cache:
+    #       paths:
+    #         - node_modules
+    #       key: v1-dependencies-{{ checksum "package.json" }}
 
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+    #   # run tests!
+    #   - run: yarn test
+    # test:
 
-      # run tests!
-      - run: yarn test
+
+# workflows:
+#   version: 2
+#   build-test-and-deploy:
+#     jobs:
+#       - build
+#       - test1:
+#           requires:
+#             - build
+#       - test2:
+#           requires:
+#             - test1
+#       - deploy:
+#           requires:
+#             - test2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,12 @@ jobs:
 
     steps:
       - checkout
-      - run: cd firebase
       - run:
              name: Deploy Cloud Functions to Firebase
-             command: firebase deploy --token=$FIREBASE_DEPLOY_TOKEN
+             command: |
+              cd firebase
+              firebase use test
+              firebase deploy --only functions --token=$FIREBASE_TOKEN
 
       # - hello/hello
       # - firebase-deploy/deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,59 +31,59 @@ jobs:
           firebase use test
           firebase deploy --token=$FIREBASE_TOKEN
   
-  test-firebase-cloud-functions:
-    docker:
-      - image: eeeeeric/circleci-docker-image:latest
-    working_directory: ~/mystic-the-get-together
-    steps:
-      - checkout
-      - restore_cache:
-        keys:
-          - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - functions-dependencies-
-      - run: 
-        name: Install Node Dependencies for Cloud Functions
-        command: |
-          cd firebase/functions
-          npm install
-      - save_cache:
-        paths:
-          - firebase/functions/node_modules
-        key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-      - run:
-        name: Execute Firebase Cloud Functions Tests
-        command: |
-          cd firebase/functions
-          echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-          npm run fb-clean && npm test
+  # test-firebase-cloud-functions:
+  #   docker:
+  #     - image: eeeeeric/circleci-docker-image:latest
+  #   working_directory: ~/mystic-the-get-together
+  #   steps:
+  #     - checkout
+  #     - restore_cache:
+  #       keys:
+  #         - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+  #         # fallback to using the latest cache if no exact match is found
+  #         - functions-dependencies-
+  #     - run: 
+  #       name: Install Node Dependencies for Cloud Functions
+  #       command: |
+  #         cd firebase/functions
+  #         npm install
+  #     - save_cache:
+  #       paths:
+  #         - firebase/functions/node_modules
+  #       key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+  #     - run:
+  #       name: Execute Firebase Cloud Functions Tests
+  #       command: |
+  #         cd firebase/functions
+  #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+  #         npm run fb-clean && npm test
 
-  test-firebase-security-rules:
-    docker:
-      - image: eeeeeric/circleci-docker-image:latest
-    working_directory: ~/mystic-the-get-together
-    steps:
-      - checkout
-      - restore_cache:
-        keys:
-          - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - security-rules-dependencies-
-      - run: 
-        name: Install Node Dependencies for Security Rules Tests
-        command: |
-          cd firebase/tests/firestore-rules
-          npm install
-      - save_cache:
-        paths:
-          - firebase/tests/firestore-rules/node_modules
-        key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-      - run:
-        name: Execute Firestore Security Rules Tests
-        command: |
-          cd firebase/tests/firestore-rules
-          echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-          npm test
+  # test-firebase-security-rules:
+  #   docker:
+  #     - image: eeeeeric/circleci-docker-image:latest
+  #   working_directory: ~/mystic-the-get-together
+  #   steps:
+  #     - checkout
+  #     - restore_cache:
+  #       keys:
+  #         - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+  #         # fallback to using the latest cache if no exact match is found
+  #         - security-rules-dependencies-
+  #     - run: 
+  #       name: Install Node Dependencies for Security Rules Tests
+  #       command: |
+  #         cd firebase/tests/firestore-rules
+  #         npm install
+  #     - save_cache:
+  #       paths:
+  #         - firebase/tests/firestore-rules/node_modules
+  #       key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+  #     - run:
+  #       name: Execute Firestore Security Rules Tests
+  #       command: |
+  #         cd firebase/tests/firestore-rules
+  #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+  #         npm test
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,28 +4,6 @@
 #
 version: 2.1
 jobs:
-  # build-firebase:
-  #   docker:
-  #     - image: eeeeeric/circleci-docker-image:latest
-  #   working_directory: ~/mystic-the-get-together
-  #   steps:
-  #     - checkout
-  #     # Download and cache dependencies
-  #     - restore_cache:
-  #         keys:
-  #           - v1-dependencies-{{ checksum "firebase/functions/package.json" }}
-  #           # fallback to using the latest cache if no exact match is found
-  #           - v1-dependencies-
-  #     - run: 
-  #       name: Install Node Dependencies for Cloud Functions
-  #       command: |
-  #         cd firebase/functions
-  #         npm install
-  #     - save_cache:
-  #         paths:
-  #           - firebase/functions/node_modules
-  #         key: v1-dependencies-{{ checksum "firebase/functions/package.json" }}
-
   deploy-firebase-test:
     docker:
       - image: eeeeeric/circleci-docker-image:latest
@@ -33,19 +11,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - functions-dependencies-
+				keys:
+					- functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+					# fallback to using the latest cache if no exact match is found
+					- functions-dependencies-
       - run: 
         name: Install Node Dependencies for Cloud Functions
         command: |
           cd firebase/functions
           npm install
       - save_cache:
-          paths:
-            - firebase/functions/node_modules
-          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+				paths:
+					- firebase/functions/node_modules
+				key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
         name: Deploy Cloud Functions to Firebase TEST Environment
         command: |
@@ -60,19 +38,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - functions-dependencies-
+				keys:
+					- functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+					# fallback to using the latest cache if no exact match is found
+					- functions-dependencies-
       - run: 
         name: Install Node Dependencies for Cloud Functions
         command: |
           cd firebase/functions
           npm install
       - save_cache:
-          paths:
-            - firebase/functions/node_modules
-          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+				paths:
+					- firebase/functions/node_modules
+				key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
         name: Execute Firebase Cloud Functions Tests
         command: |
@@ -87,19 +65,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - security-rules-dependencies-
+				keys:
+					- security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+					# fallback to using the latest cache if no exact match is found
+					- security-rules-dependencies-
       - run: 
-        name: Install Node Dependencies for Cloud Functions
+        name: Install Node Dependencies for Security Rules Tests
         command: |
           cd firebase/tests/firestore-rules
           npm install
       - save_cache:
-          paths:
-            - firebase/tests/firestore-rules/node_modules
-          key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+				paths:
+					- firebase/tests/firestore-rules/node_modules
+				key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
       - run:
         name: Execute Firestore Security Rules Tests
         command: |
@@ -107,15 +85,14 @@ jobs:
           echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
           npm test
 
-
 workflows:
   version: 2
   test:
     jobs:
       - deploy-firebase-test
       - test-firebase-cloud-functions:
-          requires:
-            - deploy-firebase-test
+				requires:
+					- deploy-firebase-test
       - test-firebase-security-rules:
-          requires:
-            - test-firebase-cloud-functions
+				requires:
+					- deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
              name: Deploy Cloud Functions to Firebase
              command: |
               cd firebase/functions
-              npm run install
+              npm install
               firebase use test
               firebase deploy --only functions --token=$FIREBASE_TOKEN
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,19 +11,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-				keys:
-					- functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-					# fallback to using the latest cache if no exact match is found
-					- functions-dependencies-
+        keys:
+          - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - functions-dependencies-
       - run: 
         name: Install Node Dependencies for Cloud Functions
         command: |
           cd firebase/functions
           npm install
       - save_cache:
-				paths:
-					- firebase/functions/node_modules
-				key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+        paths:
+          - firebase/functions/node_modules
+        key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
         name: Deploy Cloud Functions to Firebase TEST Environment
         command: |
@@ -38,19 +38,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-				keys:
-					- functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-					# fallback to using the latest cache if no exact match is found
-					- functions-dependencies-
+        keys:
+          - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - functions-dependencies-
       - run: 
         name: Install Node Dependencies for Cloud Functions
         command: |
           cd firebase/functions
           npm install
       - save_cache:
-				paths:
-					- firebase/functions/node_modules
-				key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+        paths:
+          - firebase/functions/node_modules
+        key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
         name: Execute Firebase Cloud Functions Tests
         command: |
@@ -65,19 +65,19 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-				keys:
-					- security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-					# fallback to using the latest cache if no exact match is found
-					- security-rules-dependencies-
+        keys:
+          - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - security-rules-dependencies-
       - run: 
         name: Install Node Dependencies for Security Rules Tests
         command: |
           cd firebase/tests/firestore-rules
           npm install
       - save_cache:
-				paths:
-					- firebase/tests/firestore-rules/node_modules
-				key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+        paths:
+          - firebase/tests/firestore-rules/node_modules
+        key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
       - run:
         name: Execute Firestore Security Rules Tests
         command: |
@@ -91,8 +91,8 @@ workflows:
     jobs:
       - deploy-firebase-test
       - test-firebase-cloud-functions:
-				requires:
-					- deploy-firebase-test
+        requires:
+          - deploy-firebase-test
       - test-firebase-security-rules:
-				requires:
-					- deploy-firebase-test
+        requires:
+          - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - checkout
-      - ls -la
+      - run: ls -la
     #   # Download and cache dependencies
     #   - restore_cache:
     #       keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ workflows:
       - deploy-firebase-test
       - test-firebase-cloud-functions:
           requires:
-            - deply-firebase-test
+            - deploy-firebase-test
       - test-firebase-security-rules:
           requires:
             - test-firebase-cloud-functions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ jobs:
       - run: cd firebase
       - firebase-deploy/deploy:
         token: $FIREBASE_TOKEN
+
     #   # Download and cache dependencies
     #   - restore_cache:
     #       keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,8 @@ jobs:
       - run:
              name: Deploy Cloud Functions to Firebase
              command: |
-              cd firebase
+              cd firebase/functions
+              npm run install
               firebase use test
               firebase deploy --only functions --token=$FIREBASE_TOKEN
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,9 @@ jobs:
       - run:
         name: Deploy Cloud Functions to Firebase TEST Environment
         command: |
-        cd firebase
-        firebase use test
-        firebase deploy --token=$FIREBASE_TOKEN
+          cd firebase
+          firebase use test
+          firebase deploy --token=$FIREBASE_TOKEN
   
   test-firebase-cloud-functions:
     docker:
@@ -76,9 +76,9 @@ jobs:
       - run:
         name: Execute Firebase Cloud Functions Tests
         command: |
-        cd firebase/functions
-        echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-        npm run fb-clean && npm test
+          cd firebase/functions
+          echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+          npm run fb-clean && npm test
 
   test-firebase-security-rules:
     docker:
@@ -103,9 +103,9 @@ jobs:
       - run:
         name: Execute Firestore Security Rules Tests
         command: |
-        cd firebase/tests/firestore-rules
-        echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-        npm test
+          cd firebase/tests/firestore-rules
+          echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+          npm test
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,32 +59,32 @@ jobs:
             firebase use test
             npm run fb-clean && npm test
 
-  # test-firebase-security-rules:
-  #   docker:
-  #     - image: eeeeeric/circleci-docker-image:latest
-  #   working_directory: ~/mystic-the-get-together
-  #   steps:
-  #     - checkout
-  #     - restore_cache:
-  #         keys:
-  #           - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-  #           # fallback to using the latest cache if no exact match is found
-  #           - security-rules-dependencies-
-  #     - run: 
-  #         name: Install Node Dependencies for Security Rules Tests
-  #         command: |
-  #           cd firebase/tests/firestore-rules
-  #           npm install
-  #     - save_cache:
-  #         paths:
-  #           - firebase/tests/firestore-rules/node_modules
-  #         key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-  #     - run:
-  #         name: Execute Firestore Security Rules Tests
-  #         command: |
-  #           cd firebase/tests/firestore-rules
-  #           echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-  #           npm test
+  test-firebase-security-rules:
+    docker:
+      - image: eeeeeric/circleci-docker-image:latest
+    working_directory: ~/mystic-the-get-together
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - security-rules-dependencies-
+      - run: 
+          name: Install Node Dependencies for Security Rules Tests
+          command: |
+            cd firebase/tests/firestore-rules
+            npm install
+      - save_cache:
+          paths:
+            - firebase/tests/firestore-rules/node_modules
+          key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+      - run:
+          name: Execute Firestore Security Rules Tests
+          command: |
+            cd firebase/tests/firestore-rules
+            echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+            npm test
 
 workflows:
   version: 2
@@ -94,6 +94,6 @@ workflows:
       - test-firebase-cloud-functions:
           requires:
             - deploy-firebase-test
-      # - test-firebase-security-rules:
-      #     requires:
-      #       - deploy-firebase-test
+      - test-firebase-security-rules:
+          requires:
+            - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+orbs:
+  firebase-deploy: cloudliner/firebase-deploy@0.0.2
 general:
   branches:
     only:
@@ -18,11 +20,14 @@ jobs:
       # documented at https://circleci.com/docs/2.0/circleci-images/
       # - image: circleci/mongo:3.4.4
 
-    working_directory: ~/repo
+    working_directory: ~/mystic-the-get-together
 
     steps:
       - checkout
-      - run: ls -la
+      - run: cd firebase
+      - run: echo $TEST_VAR
+      # - firebase-deploy:
+      #   token: $FIREBASE_DEPLOY_TOKEN
     #   # Download and cache dependencies
     #   - restore_cache:
     #       keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - run: cd firebase
       - firebase-deploy/deploy:
-        token: $FIREBASE_TOKEN
+        token: "$FIREBASE_TOKEN"
 
     #   # Download and cache dependencies
     #   - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
           command: |
             cd firebase/functions
             echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+            firebase use test
             npm run fb-clean && npm test
 
   # test-firebase-security-rules:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,14 +85,14 @@ jobs:
   #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
   #         npm test
 
-workflows:
-  version: 2
-  test:
-    jobs:
-      - deploy-firebase-test
-      - test-firebase-cloud-functions:
-        requires:
-          - deploy-firebase-test
-      - test-firebase-security-rules:
-        requires:
-          - deploy-firebase-test
+# workflows:
+#   version: 2
+#   test:
+#     jobs:
+#       - deploy-firebase-test
+#       - test-firebase-cloud-functions:
+#         requires:
+#           - deploy-firebase-test
+#       - test-firebase-security-rules:
+#         requires:
+#           - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,14 +85,14 @@ jobs:
   #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
   #         npm test
 
-# workflows:
-#   version: 2
-#   test:
-#     jobs:
-#       - deploy-firebase-test
-#       - test-firebase-cloud-functions:
-#         requires:
-#           - deploy-firebase-test
-#       - test-firebase-security-rules:
-#         requires:
-#           - deploy-firebase-test
+workflows:
+  version: 2
+  test:
+    jobs:
+      - deploy-firebase-test
+      # - test-firebase-cloud-functions:
+      #   requires:
+      #     - deploy-firebase-test
+      # - test-firebase-security-rules:
+      #   requires:
+      #     - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,68 +31,68 @@ jobs:
             firebase use test
             firebase deploy --token=$FIREBASE_TOKEN
   
-  # test-firebase-cloud-functions:
-  #   docker:
-  #     - image: eeeeeric/circleci-docker-image:latest
-  #   working_directory: ~/mystic-the-get-together
-  #   steps:
-  #     - checkout
-  #     - restore_cache:
-  #       keys:
-  #         - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-  #         # fallback to using the latest cache if no exact match is found
-  #         - functions-dependencies-
-  #     - run: 
-  #       name: Install Node Dependencies for Cloud Functions
-  #       command: |
-  #         cd firebase/functions
-  #         npm install
-  #     - save_cache:
-  #       paths:
-  #         - firebase/functions/node_modules
-  #       key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-  #     - run:
-  #       name: Execute Firebase Cloud Functions Tests
-  #       command: |
-  #         cd firebase/functions
-  #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-  #         npm run fb-clean && npm test
+  test-firebase-cloud-functions:
+    docker:
+      - image: eeeeeric/circleci-docker-image:latest
+    working_directory: ~/mystic-the-get-together
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - functions-dependencies-
+      - run: 
+          name: Install Node Dependencies for Cloud Functions
+          command: |
+            cd firebase/functions
+            npm install
+      - save_cache:
+          paths:
+            - firebase/functions/node_modules
+          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+      - run:
+          name: Execute Firebase Cloud Functions Tests
+          command: |
+            cd firebase/functions
+            echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+            npm run fb-clean && npm test
 
-  # test-firebase-security-rules:
-  #   docker:
-  #     - image: eeeeeric/circleci-docker-image:latest
-  #   working_directory: ~/mystic-the-get-together
-  #   steps:
-  #     - checkout
-  #     - restore_cache:
-  #       keys:
-  #         - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-  #         # fallback to using the latest cache if no exact match is found
-  #         - security-rules-dependencies-
-  #     - run: 
-  #       name: Install Node Dependencies for Security Rules Tests
-  #       command: |
-  #         cd firebase/tests/firestore-rules
-  #         npm install
-  #     - save_cache:
-  #       paths:
-  #         - firebase/tests/firestore-rules/node_modules
-  #       key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-  #     - run:
-  #       name: Execute Firestore Security Rules Tests
-  #       command: |
-  #         cd firebase/tests/firestore-rules
-  #         echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-  #         npm test
+  test-firebase-security-rules:
+    docker:
+      - image: eeeeeric/circleci-docker-image:latest
+    working_directory: ~/mystic-the-get-together
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - security-rules-dependencies-
+      - run: 
+          name: Install Node Dependencies for Security Rules Tests
+          command: |
+            cd firebase/tests/firestore-rules
+            npm install
+      - save_cache:
+          paths:
+            - firebase/tests/firestore-rules/node_modules
+          key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+      - run:
+          name: Execute Firestore Security Rules Tests
+          command: |
+            cd firebase/tests/firestore-rules
+            echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+            npm test
 
 workflows:
   version: 2
   test:
     jobs:
       - deploy-firebase-test
-      # - test-firebase-cloud-functions:
-      #   requires:
-      #     - deploy-firebase-test
-      # - test-firebase-security-rules:
-      #   requires:
-      #     - deploy-firebase-test
+      - test-firebase-cloud-functions:
+          requires:
+            - deploy-firebase-test
+      - test-firebase-security-rules:
+          requires:
+            - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,70 +3,119 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2.1
-# orbs:
-#   firebase-deploy: cloudliner/firebase-deploy@0.0.2
-#   hello: circleci/hello-build@0.0.5
-general:
-  branches:
-    only:
-      - circleci
 jobs:
-  build:
+  # build-firebase:
+  #   docker:
+  #     - image: eeeeeric/circleci-docker-image:latest
+  #   working_directory: ~/mystic-the-get-together
+  #   steps:
+  #     - checkout
+  #     # Download and cache dependencies
+  #     - restore_cache:
+  #         keys:
+  #           - v1-dependencies-{{ checksum "firebase/functions/package.json" }}
+  #           # fallback to using the latest cache if no exact match is found
+  #           - v1-dependencies-
+  #     - run: 
+  #       name: Install Node Dependencies for Cloud Functions
+  #       command: |
+  #         cd firebase/functions
+  #         npm install
+  #     - save_cache:
+  #         paths:
+  #           - firebase/functions/node_modules
+  #         key: v1-dependencies-{{ checksum "firebase/functions/package.json" }}
+
+  deploy-firebase-test:
     docker:
-      # specify the version you desire here
       - image: eeeeeric/circleci-docker-image:latest
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/mongo:3.4.4
-
     working_directory: ~/mystic-the-get-together
-
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - functions-dependencies-
+      - run: 
+        name: Install Node Dependencies for Cloud Functions
+        command: |
+          cd firebase/functions
+          npm install
+      - save_cache:
+          paths:
+            - firebase/functions/node_modules
+          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
-             name: Deploy Cloud Functions to Firebase
-             command: |
-              cd firebase/functions
-              npm install
-              firebase use test
-              firebase deploy --only functions --token=$FIREBASE_TOKEN
+        name: Deploy Cloud Functions to Firebase TEST Environment
+        command: |
+        cd firebase
+        firebase use test
+        firebase deploy --token=$FIREBASE_TOKEN
+  
+  test-firebase-cloud-functions:
+    docker:
+      - image: eeeeeric/circleci-docker-image:latest
+    working_directory: ~/mystic-the-get-together
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - functions-dependencies-
+      - run: 
+        name: Install Node Dependencies for Cloud Functions
+        command: |
+          cd firebase/functions
+          npm install
+      - save_cache:
+          paths:
+            - firebase/functions/node_modules
+          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+      - run:
+        name: Execute Firebase Cloud Functions Tests
+        command: |
+        cd firebase/functions
+        echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+        npm run fb-clean && npm test
 
-      # - hello/hello
-      # - firebase-deploy/deploy:
-      #   token: "$FIREBASE_TOKEN"
+  test-firebase-security-rules:
+    docker:
+      - image: eeeeeric/circleci-docker-image:latest
+    working_directory: ~/mystic-the-get-together
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - security-rules-dependencies-
+      - run: 
+        name: Install Node Dependencies for Cloud Functions
+        command: |
+          cd firebase/tests/firestore-rules
+          npm install
+      - save_cache:
+          paths:
+            - firebase/tests/firestore-rules/node_modules
+          key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+      - run:
+        name: Execute Firestore Security Rules Tests
+        command: |
+        cd firebase/tests/firestore-rules
+        echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+        npm test
 
-    #   # Download and cache dependencies
-    #   - restore_cache:
-    #       keys:
-    #         - v1-dependencies-{{ checksum "package.json" }}
-    #         # fallback to using the latest cache if no exact match is found
-    #         - v1-dependencies-
 
-    #   - run: yarn install
-
-    #   - save_cache:
-    #       paths:
-    #         - node_modules
-    #       key: v1-dependencies-{{ checksum "package.json" }}
-
-    #   # run tests!
-    #   - run: yarn test
-    # test:
-
-
-# workflows:
-#   version: 2
-#   build-test-and-deploy:
-#     jobs:
-#       - build
-#       - test1:
-#           requires:
-#             - build
-#       - test2:
-#           requires:
-#             - test1
-#       - deploy:
-#           requires:
-#             - test2
+workflows:
+  version: 2
+  test:
+    jobs:
+      - deploy-firebase-test
+      - test-firebase-cloud-functions:
+          requires:
+            - deply-firebase-test
+      - test-firebase-security-rules:
+          requires:
+            - test-firebase-cloud-functions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - checkout
       - run: cd firebase
-      - firebase-deploy:
+      - firebase-deploy/deploy:
         token: $FIREBASE_TOKEN
     #   # Download and cache dependencies
     #   - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,9 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2.1
-orbs:
-  firebase-deploy: cloudliner/firebase-deploy@0.0.2
+# orbs:
+#   firebase-deploy: cloudliner/firebase-deploy@0.0.2
+#   hello: circleci/hello-build@0.0.5
 general:
   branches:
     only:
@@ -13,7 +14,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.15.0
+      - image: eeeeeric/circleci-docker-image:latest
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -25,8 +26,13 @@ jobs:
     steps:
       - checkout
       - run: cd firebase
-      - firebase-deploy/deploy:
-        token: "$FIREBASE_TOKEN"
+      - run:
+             name: Deploy Cloud Functions to Firebase
+             command: firebase deploy --token=$FIREBASE_DEPLOY_TOKEN
+
+      # - hello/hello
+      # - firebase-deploy/deploy:
+      #   token: "$FIREBASE_TOKEN"
 
     #   # Download and cache dependencies
     #   - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,32 +58,32 @@ jobs:
             echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
             npm run fb-clean && npm test
 
-  test-firebase-security-rules:
-    docker:
-      - image: eeeeeric/circleci-docker-image:latest
-    working_directory: ~/mystic-the-get-together
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - security-rules-dependencies-
-      - run: 
-          name: Install Node Dependencies for Security Rules Tests
-          command: |
-            cd firebase/tests/firestore-rules
-            npm install
-      - save_cache:
-          paths:
-            - firebase/tests/firestore-rules/node_modules
-          key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
-      - run:
-          name: Execute Firestore Security Rules Tests
-          command: |
-            cd firebase/tests/firestore-rules
-            echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
-            npm test
+  # test-firebase-security-rules:
+  #   docker:
+  #     - image: eeeeeric/circleci-docker-image:latest
+  #   working_directory: ~/mystic-the-get-together
+  #   steps:
+  #     - checkout
+  #     - restore_cache:
+  #         keys:
+  #           - security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+  #           # fallback to using the latest cache if no exact match is found
+  #           - security-rules-dependencies-
+  #     - run: 
+  #         name: Install Node Dependencies for Security Rules Tests
+  #         command: |
+  #           cd firebase/tests/firestore-rules
+  #           npm install
+  #     - save_cache:
+  #         paths:
+  #           - firebase/tests/firestore-rules/node_modules
+  #         key: security-rules-dependencies-{{ checksum "firebase/tests/firestore-rules/package.json" }}
+  #     - run:
+  #         name: Execute Firestore Security Rules Tests
+  #         command: |
+  #           cd firebase/tests/firestore-rules
+  #           echo $SERVICE_ACCOUNT_CREDENTIALS_JSON > service-account-credentials.json
+  #           npm test
 
 workflows:
   version: 2
@@ -93,6 +93,6 @@ workflows:
       - test-firebase-cloud-functions:
           requires:
             - deploy-firebase-test
-      - test-firebase-security-rules:
-          requires:
-            - deploy-firebase-test
+      # - test-firebase-security-rules:
+      #     requires:
+      #       - deploy-firebase-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2.1
+version: 2.0
 jobs:
   deploy-firebase-test:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,8 @@ jobs:
     steps:
       - checkout
       - run: cd firebase
-      - run: echo $TEST_VAR
-      # - firebase-deploy:
-      #   token: $FIREBASE_DEPLOY_TOKEN
+      - firebase-deploy:
+        token: $FIREBASE_TOKEN
     #   # Download and cache dependencies
     #   - restore_cache:
     #       keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,25 +11,25 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-        keys:
-          - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - functions-dependencies-
+          keys:
+            - functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - functions-dependencies-
       - run: 
-        name: Install Node Dependencies for Cloud Functions
-        command: |
-          cd firebase/functions
-          npm install
+          name: Install Node Dependencies for Cloud Functions
+          command: |
+            cd firebase/functions
+            npm install
       - save_cache:
-        paths:
-          - firebase/functions/node_modules
-        key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
+          paths:
+            - firebase/functions/node_modules
+          key: functions-dependencies-{{ checksum "firebase/functions/package.json" }}
       - run:
-        name: Deploy Cloud Functions to Firebase TEST Environment
-        command: |
-          cd firebase
-          firebase use test
-          firebase deploy --token=$FIREBASE_TOKEN
+          name: Deploy Cloud Functions to Firebase TEST Environment
+          command: |
+            cd firebase
+            firebase use test
+            firebase deploy --token=$FIREBASE_TOKEN
   
   # test-firebase-cloud-functions:
   #   docker:


### PR DESCRIPTION
This adds initial support for CircleCI. Right now, it will deploy all the Firebase portions of the project to a dedicated test environment (this is currently an environment that only I can access, but we should make it accessible between all team members in the future). It will then execute the tests for the Cloud Functions. There is commented out support for the Security Rules, which can be enabled once #63 is merged.

This requires that two environment variables be set in CircleCI:
- FIREBASE_TOKEN (this can be generated using the firebase CLI and the `login:ci` subcommand)
- SERVICE_ACCOUNT_CREDENTIALS_JSON (how to get the contents of the file/var is described in the Cloud Functions README)

This config depends on a custom Docker image that can be found at eeeeeric/circleci-docker-image - this is a project that should eventually be migrated to warlocks-of-the-midwest/mystic-ci-docker-image.

We should open additional issues to
- execute UI tests (once those are created)
- deploy to prod (once hosting is configured)

Resolves #19  