### PR TITLE
Reducers are now properly stateless;

### DIFF
--- a/client/src/components/GameArea.js
+++ b/client/src/components/GameArea.js
@@ -185,8 +185,6 @@ class GameArea extends Component {
 
 GameArea.contextType = GameContext;
 
-GameArea.propTypes = {
-  cards: PropTypes.array.isRequired,
-};
+GameArea.propTypes = {};
 
 export default GameArea;

--- a/client/src/context/gameContext.js
+++ b/client/src/context/gameContext.js
@@ -55,7 +55,7 @@ export const GameProvider = (props) => {
   };
 
   const cardUpdate = (data) => {
-    const updatedCards = cardsRef.current;
+    const updatedCards = cardsRef.current.slice();
 
     const updatedIndex = updatedCards.findIndex(
       (element) => element.id === data.id
@@ -77,7 +77,7 @@ export const GameProvider = (props) => {
   };
 
   const playerUpdate = (data) => {
-    const updatedPlayers = playersRef.current;
+    const updatedPlayers = playersRef.current.slice();
 
     const updatedIndex = updatedPlayers.findIndex(
       (element) => element.id === data.id

--- a/client/src/context/gameContext.js
+++ b/client/src/context/gameContext.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect } from 'react';
+import React, { useReducer, useEffect, useRef } from 'react';
 import _ from 'lodash';
 
 import gameStateReducer, { GameActions } from '../reducers/gameStateReducer';
@@ -25,6 +25,12 @@ export const GameProvider = (props) => {
 
   const [gameState, dispatch] = useReducer(gameStateReducer, initialGameState);
 
+  // cardUpdate()/playerUpdate() will only see the value of gameState and
+  // props as they are during the initial call of useEffect.init() -- so
+  // this reference allows these functions to access the current state
+  const cardsRef = useRef(gameState.cards);
+  const playersRef = useRef(gameState.players);
+
   const loadCards = (data) => {
     const cards = _.map(_.keys(data), (cardId) => data[cardId]);
     const scryfallIds = _.map(cards, (card) => _.get(card, 'scryfall_id', null));
@@ -49,11 +55,41 @@ export const GameProvider = (props) => {
   };
 
   const cardUpdate = (data) => {
-    // console.log('listening');
+    const updatedCards = cardsRef.current;
+
+    const updatedIndex = updatedCards.findIndex(
+      (element) => element.id === data.id
+    );
+
+    if (updatedIndex < 0) {
+      return;
+    }
+
+    /*
+    console.log(`Changing zone of card ${data.id} from `
+    + `${updatedCards[updatedIndex].state.zone} to `
+    + `${data.state.zone}`);
+    */
+
+    updatedCards[updatedIndex].state = data.state;
+
+    dispatch({ type: GameActions.UPDATE_CARD, payload: updatedCards });
   };
 
   const playerUpdate = (data) => {
-    // console.log('listening');
+    const updatedPlayers = playersRef.current;
+
+    const updatedIndex = updatedPlayers.findIndex(
+      (element) => element.id === data.id
+    );
+
+    if (updatedIndex < 0) {
+      return;
+    }
+
+    updatedPlayers[updatedIndex] = data;
+
+    dispatch({ type: GameActions.UPDATE_PLAYER, payload: updatedPlayers });
   };
 
   useEffect(() => {
@@ -78,6 +114,14 @@ export const GameProvider = (props) => {
 
     init();
   }, []);
+
+  // Make sure that cardsRef and playersRef stay up-to-date with game state
+  useEffect(
+    () => {
+      cardsRef.current = gameState.cards;
+      playersRef.current = gameState.players;
+    }, [gameState]
+  );
 
   return (
     <GameContext.Provider value={{ gameState }}>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -17,7 +17,7 @@ const AuthenticatedGameProvider = withAuthentication(GameProvider);
 
 const GameContainer = (props) => (
   <AuthenticatedGameProvider {...props}>
-    <GameArea />
+    <GameArea cards={[]} />
   </AuthenticatedGameProvider>
 );
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -17,7 +17,7 @@ const AuthenticatedGameProvider = withAuthentication(GameProvider);
 
 const GameContainer = (props) => (
   <AuthenticatedGameProvider {...props}>
-    <GameArea cards={[]} />
+    <GameArea />
   </AuthenticatedGameProvider>
 );
 

--- a/client/src/reducers/gameStateReducer.js
+++ b/client/src/reducers/gameStateReducer.js
@@ -1,5 +1,6 @@
 export const GameActions = {
   UPDATE_PLAYER: 'UPDATE_PLAYER',
+  UPDATE_CARD: 'UPDATE_CARD',
   LOAD_PLAYERS: 'LOAD_PLAYERS',
   LOAD_CARDS: 'LOAD_CARDS',
 };
@@ -19,12 +20,15 @@ const gameStateReducer = (state, action) => {
       };
     }
     case GameActions.UPDATE_CARD: {
-      const newCards = state.Cards;
-      // TODO handling cards getting deleted/removed?
-      newCards[action.payload.card.cardId] = action.payload.card;
       return {
         ...state,
-        Cards: newCards,
+        cards: action.payload,
+      };
+    }
+    case GameActions.UPDATE_PLAYER: {
+      return {
+        ...state,
+        players: action.payload,
       };
     }
     default:


### PR DESCRIPTION
When I started working on the reducers again, I remember why I put state stuff into the reducers -- it wasn't that gameState was out of scope, it was that gameState in cardUpdate() was empty. I'm pretty sure this is because of the problem described here: https://dev.to/scastiel/react-hooks-get-the-current-state-back-to-the-future-3op2 
I implemented the suggested workaround of using useRef() and the board now updates automatically when I manipulate the firebase database. Note that these changes are just for the reducers -- there aren't any modal changes here.